### PR TITLE
reelase/v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "rslack"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rslack"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["kohbis <dev.kohbis@gmail.com>"]
 edition = "2021"
 description = "cli for posting slack message"


### PR DESCRIPTION
- update edition to 2021
- update Cargo.lock via cargo build
- release v0.2.0
