### PR TITLE
bump version termion 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "1.5.6"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+checksum = "659c1f379f3408c7e5e84c7d0da6d93404e3800b6b9d063ba24436419302ec90"
 dependencies = [
  "libc",
  "numtoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ reqwest = { version = "0.11.12", features = ["json"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 structopt = "0.3.20"
-termion = "1.5.6"
+termion = "2.0.1"
 tokio = { version = "1.21.2", features = ["full"] }
 unicode-width = "0.1.10"
 url = "2.3.1"

--- a/src/bin/rslack.rs
+++ b/src/bin/rslack.rs
@@ -3,7 +3,7 @@ use std::io::{stdin, stdout, Write};
 use termion::event::Key;
 use termion::input::TermRead;
 use termion::raw::IntoRawMode;
-use termion::screen::AlternateScreen;
+use termion::screen::IntoAlternateScreen;
 
 use rslack::api;
 use rslack::config::Config;
@@ -46,7 +46,7 @@ async fn main() {
 
     let stdout = stdout().into_raw_mode().unwrap();
     // Switch screen from Main to Alternate
-    let mut stdout = AlternateScreen::from(stdout);
+    let mut stdout = stdout.into_alternate_screen().unwrap();
 
     if channel.trim().is_empty() || !channel_names.contains(&channel.as_str()) {
         let mut current: (usize, usize) = (0, 0);


### PR DESCRIPTION
- Bump termion from 1.5.6 to 2.0.1

dependabot: https://github.com/kohbis/rslack/pull/118
ref: https://github.com/redox-os/termion/commit/0082c8da04f861b677dee1e8da9c56bdffd3f422
